### PR TITLE
Fix theme to restore original white background with purple app bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,9 +15,13 @@ class AubeReveApp extends StatelessWidget {
         home: const DiceRoller(),
         theme: ThemeData(
             primaryColor: Colors.purple,
+            appBarTheme: const AppBarTheme(
+              backgroundColor: Colors.purple,
+              foregroundColor: Colors.white,
+            ),
             colorScheme: ColorScheme.fromSeed(
               seedColor: Colors.purple,
-              surface: Colors.purpleAccent,
+              brightness: Brightness.light,
             )));
   }
 }


### PR DESCRIPTION
The ColorScheme.fromSeed was applying purple to the scaffold background. Updated to use explicit AppBarTheme for the purple app bar while keeping the default light theme background.